### PR TITLE
Update new schema 1.3.2

### DIFF
--- a/DCC.combined-schema.json
+++ b/DCC.combined-schema.json
@@ -3,7 +3,7 @@
   "$id": "https://id.uvci.eu/DCC.combined-schema.json",
   "title": "EU DCC",
   "description": "EU Digital Covid Certificate",
-  "$comment": "Schema version 1.3.0",
+  "$comment": "Schema version 1.3.2",
   "type": "object",
   "oneOf": [
     {
@@ -38,7 +38,10 @@
       "type": "string",
       "pattern": "^\\d+.\\d+.\\d+$",
       "examples": [
-        "1.3.0"
+        "1.0.0",
+        "1.3.0",
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "nam": {
@@ -98,8 +101,17 @@
     },
     "person_name": {
       "description": "Person name: Surname(s), forename(s) - in that order",
-      "required": [
-        "fnt"
+      "anyOf": [
+        {
+          "required": [
+            "fnt"
+          ]
+        },
+        {
+          "required": [
+            "gnt"
+          ]
+        }
       ],
       "type": "object",
       "properties": {
@@ -221,6 +233,7 @@
       "type": "object",
       "properties": {
         "tg": {
+          "description": "disease or agent targeted",
           "$ref": "#/$defs/disease-agent-targeted"
         },
         "tt": {
@@ -278,6 +291,7 @@
       "type": "object",
       "properties": {
         "tg": {
+          "description": "disease or agent targeted",
           "$ref": "#/$defs/disease-agent-targeted"
         },
         "fr": {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains documentation about certification endpoints and related flows for authentication and authorization to be integrated with information systems of physicians, pharmacies and vaccination centers.
 
-The interface specifications are aligned with the DGC schema specification published in version [1.3.0](https://github.com/ehn-digital-green-development/ehn-dgc-schema/releases/tag/1.3.0).
+The interface specifications are aligned with the DGC schema specification published in version [1.3.2](https://github.com/ehn-dcc-development/eu-dcc-schema/releases/tag/1.3.2).
 
 ## OpenAPI Specifications
 

--- a/dcc-certify-api.yaml
+++ b/dcc-certify-api.yaml
@@ -300,21 +300,23 @@ components:
           title: Person name
           description: Name of the person which receives the certificate.
           type: object
-          required:
-            - fn
-          properties:
-            fn:
-              title: Family name
-              description: The family or primary name(s) of the person addressed in the certificate
-              type: string
-              maxLength: 80
-              example: "Musterfrau-Dießner"
-            gn:
-              title: Given name
-              description: The given name(s) of the person addressed in the certificate
-              type: string
-              maxLength: 80
-              example: "Erika Dörte"
+          anyOf:
+          - properties:
+              fn:
+                title: Family name
+                description: The family or primary name(s) of the person addressed in the certificate
+                type: string
+                maxLength: 80
+                example: "Musterfrau-Dießner"
+            required: [ fn ]
+          - properties:
+              gn:
+                title: Given name
+                description: The given name(s) of the person addressed in the certificate
+                type: string
+                maxLength: 80
+                example: "Erika Dörte"
+            required: [ gn ]
         dob:
           title: Date of birth
           description: Date of Birth of the person addressed in the DGC. ISO 8601 date format restricted to range 1900-2099


### PR DESCRIPTION
This update modifies the API definition to the new changes allowing either fn or gn instead of `fn` being a must (in the schema it is fnt/gnt). Also updates the value sets link.